### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DryViews [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/pboling/dry_views) [![Inline docs](http://inch-pages.github.io/github/pboling/dry_views.png)](http://inch-pages.github.io/github/pboling/dry_views) [![Build Status](https://secure.travis-ci.org/pboling/dry_views.png?branch=master)](http://travis-ci.org/pboling/dry_views) [![Endorse Me](http://api.coderwall.com/pboling/endorsecount.png)](http://coderwall.com/pboling)
+# DryViews [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/pboling/dry_views) [![Inline docs](http://inch-ci.org/github/pboling/dry_views.png)](http://inch-ci.org/github/pboling/dry_views) [![Build Status](https://secure.travis-ci.org/pboling/dry_views.png?branch=master)](http://travis-ci.org/pboling/dry_views) [![Endorse Me](http://api.coderwall.com/pboling/endorsecount.png)](http://coderwall.com/pboling)
 
 ## Why?
 


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
